### PR TITLE
fix(pfsense): VPN remote syslog vers ELK + port VPN parametre + suppr…

### DIFF
--- a/ansible/playbooks/pfsense-cloud.yml
+++ b/ansible/playbooks/pfsense-cloud.yml
@@ -19,3 +19,11 @@
     - ../vars/openvpn_secrets.yml
   roles:
     - pfsense-cloud
+  post_tasks:
+    - name: Activer le remote syslog VPN vers le collecteur
+      pfsensible.core.pfsense_log_settings:
+        enable: true
+        remoteserver: "{{ ops_collector_ip }}:5140"
+        logformat: rfc5424
+        vpn: true
+      tags: [configure, logging, vpn]

--- a/ansible/playbooks/pfsense.yml
+++ b/ansible/playbooks/pfsense.yml
@@ -81,7 +81,7 @@
         protocol: udp
         source: any
         destination: any
-        destination_port: "1194"
+        destination_port: "{{ vpn_port }}"
         state: present
       tags: [configure, firewall, vpn]
 
@@ -121,31 +121,6 @@
         - "8.8.8.8"
       tags: [configure, dns]
 
-    - name: Créer l'Autorité de Certification (CAPfsense)
-      pfsensible.core.pfsense_ca:
-        name: "CA Interne pour Vault TLS"
-        method: "internal"
-        keytype: "RSA"
-        keylen: 4096
-        digest_alg: "sha256"
-        lifetime: 3650
-        dn_country: "FR"
-        dn_state: "Ile-de-France"
-        dn_city: "Paris"
-        dn_organization: "Projet Cloud"
-        dn_commonname: "CAPfsense"
-        state: present
-      register: ca_result
-      tags: [configure, ca]
-
-    - name: Sauvegarder le certificat public CA en local
-      ansible.builtin.copy:
-        content: "{{ ca_result.ca.crt }}"
-        dest: "./CAPfsense.crt"
-      delegate_to: localhost
-      when: ca_result.ca is defined
-      tags: [configure, ca]
-
     - name: "[KILLSWITCH] Bloquer OpenVPN 1194 sur WAN"
       pfsensible.core.pfsense_rule:
         name: "KILLSWITCH_OpenVPN_1194"
@@ -154,7 +129,7 @@
         protocol: udp
         source: any
         destination: "{{ openvpn_client.server_addr }}"
-        destination_port: "1194"
+        destination_port: "{{ vpn_port }}"
         state: present
       tags: [never, killswitch]
 
@@ -199,5 +174,11 @@
         state: present
       tags: [never, restore]
 
+    - name: Activer le remote syslog VPN vers le collecteur
+      pfsensible.core.pfsense_log_settings:
+        enable: true
+        remoteserver: "{{ ops_collector_ip }}:5140"
+        logformat: rfc5424
+        vpn: true
+      tags: [configure, logging, vpn]
 
-# pfSense Cloud est configuré dans playbooks/pfsense-cloud.yml (rôle pfsense-cloud)

--- a/ansible/roles/filebeat/templates/filebeat.yml.j2
+++ b/ansible/roles/filebeat/templates/filebeat.yml.j2
@@ -17,6 +17,14 @@ filebeat.inputs:
           keys_under_root: true
           overwrite_keys: true
 
+  - type: syslog
+    enabled: true
+    format: rfc5424
+    protocol.udp:
+      host: "0.0.0.0:5140"
+    fields: { source_type: pfsense }
+    fields_under_root: true
+
 output.elasticsearch:
   hosts: ["https://{{ filebeat_elasticsearch_host }}:{{ filebeat_elasticsearch_port }}"]
   username: elastic

--- a/ansible/vars/common.yml
+++ b/ansible/vars/common.yml
@@ -19,3 +19,6 @@ pfsense_cloud_wan: "{{ lookup('env', 'PFSENSE_CLOUD_WAN') | default('') }}"
 # OpenVPN
 vpn_port: "{{ lookup('env', 'VPN_PORT') | default('1194') }}"
 vpn_tunnel_network: "{{ lookup('env', 'VPN_TUNNEL_NETWORK') | default('10.3.3.0/30') }}"
+
+# Collecteur de logs : remote syslog pfSense -> Filebeat (input syslog) sur ops-vm
+ops_collector_ip: "{{ lookup('env', 'OPS_COLLECTOR_IP') | default('172.16.0.253') }}"

--- a/terraform/modules/pfsense/PFSENSE.md
+++ b/terraform/modules/pfsense/PFSENSE.md
@@ -43,7 +43,7 @@ Les variables suivantes doivent être renseignées dans `config.env` :
 ```bash
 cd ansible
 
-# Configuration complète (firewall, VPN, DNS, CA)
+# Configuration complète (firewall, VPN, DNS)
 ansible-playbook -i inventory/onprem.py playbooks/pfsense.yml
 
 # Couper le VPN en urgence (kill-switch)
@@ -72,8 +72,6 @@ Ansible se connecte directement sur les IPs WAN avec le compte `admin` en authen
 | Règle OpenVPN interface | Autorise tout le trafic inter-sites sur l'interface OpenVPN |
 | Client OpenVPN | Connexion vers pfSense Cloud (`5.196.50.52:1194`) — tunnel `10.3.3.0/30` |
 | DNS Forwarders | `192.168.255.254` (Cloud via VPN) + `1.1.1.1` + `8.8.8.8` |
-| CA interne | Crée `CAPfsense` (RSA 4096, SHA-256, 10 ans) si absente |
-| Export CA | Sauvegarde `CAPfsense.crt` en local (uniquement à la création) |
 
 ### pfSense Cloud — Site cloud (cloud.local)
 
@@ -132,7 +130,6 @@ Accepter le certificat auto-signé lors de la première connexion.
 1. Ouvrir l'URL ci-dessus dans le navigateur
 2. Aller dans **Firewall > Rules > WAN** — les règles SSH (22), HTTPS (443) et OpenVPN (1194) doivent être présentes
 3. Aller dans **Services > DNS Forwarder** ou **DNS Resolver** pour vérifier les forwarders
-4. Aller dans **System > Cert. Manager > CAs** pour vérifier la CA `CAPfsense`
 
 ### Prérequis : SSH activé sur pfSense
 
@@ -186,6 +183,3 @@ La collection n'est pas installée :
 ansible-galaxy collection install -r requirements.yml
 ```
 
-### CA skipped à la sauvegarde
-
-La tâche "Sauvegarder le certificat public CA en local" est sautée si la CA existait déjà. C'est normal — `ca_result.ca` n'est renvoyé que lors de la création.


### PR DESCRIPTION
…ession CA morte

- feat(logs): remote syslog OpenVPN (pfsense_log_settings vpn:true) sur OP et Cloud, recu par un input syslog Filebeat (ops-vm:5140) -> Elasticsearch/Kibana
- fix(pfsense-op): destination_port en dur 1194 -> {{ vpn_port }} (regle WAN + killswitch), aligne sur le site Cloud
- feat(vars): ajout ops_collector_ip (collecteur de logs, defaut ops-vm)
- fix(yaml): correction indentation/structure (post_tasks Cloud, input syslog Filebeat remonte au bon niveau)
- chore(pfsense): suppression de la CA CAPfsense (code mort, non consommee ; la PKI reelle est le role Ansible tls) + nettoyage doc PFSENSE.md