### PR TITLE
ELK password management via Vault

### DIFF
--- a/.claude/rules/ansible.md
+++ b/.claude/rules/ansible.md
@@ -15,10 +15,10 @@ Diagnostic rapide : `python3 inventory/onprem.py | python3 -m json.tool`
 5. `filebeat.yml` — tous les hosts (dépend ELK up)
 6. `services-vm.yml` — base role sur services-vm
 
-## Variables ELK à surcharger en prod
-Dans `ansible/roles/elk/defaults/main.yml` :
-- `elk_elastic_password: "changeme"` → à mettre dans Vault
-- `elk_kibana_system_password: "changeme"` → idem
+## Mots de passe ELK — auto-gérés via Vault
+`elk_elastic_password` / `elk_kibana_system_password` (defaults `"changeme"` dans `ansible/roles/elk/defaults/main.yml`) ne servent que de bootstrap au tout premier run.
+Le rôle `elk` les stocke ensuite dans Vault (`secret/data/elk/elastic-password`, `secret/data/elk/kibana-system-password`), et les relit à chaque run suivant (cf. tâches "SECRETS DEPUIS VAULT" / "SECRETS → VAULT" en début/fin de `roles/elk/tasks/main.yml`).
+Les rôles `kibana` et `filebeat` relisent ces mêmes secrets depuis Vault (plus de variable codée en dur côté consommateur) — même schéma que le token Fleet (`secret/data/elk/fleet-enrollment-token`, écrit par `kibana`, relu par `elastic-agent`).
 
 ## Collections requises
 `ansible-galaxy collection install -r requirements.yml`  

--- a/ansible/roles/elk/tasks/main.yml
+++ b/ansible/roles/elk/tasks/main.yml
@@ -1,4 +1,53 @@
 ---
+## --- SECRETS DEPUIS VAULT (si déjà stockés par un run précédent) ---
+
+- name: Slurp vault-init.json (vault root token)
+  slurp:
+    src: /root/vault-init.json
+  become: true
+  register: elk_vault_init_raw
+  no_log: true
+
+- name: Set vault root token
+  set_fact:
+    elk_vault_root_token: "{{ (elk_vault_init_raw.content | b64decode | from_json).root_token }}"
+  no_log: true
+
+# 200 = mot de passe déjà en Vault (run précédent), 404 = absent → on garde le default puis on le stockera
+- name: Check if elastic password already in Vault
+  uri:
+    url: "https://127.0.0.1:8200/v1/secret/data/elk/elastic-password"
+    method: GET
+    headers:
+      X-Vault-Token: "{{ elk_vault_root_token }}"
+    ca_path: "{{ elk_tls_host_dir }}/ca.crt"
+    status_code: [200, 404]
+  register: elk_vault_elastic_check
+  no_log: true
+
+- name: Use elastic password from Vault
+  set_fact:
+    elk_elastic_password: "{{ elk_vault_elastic_check.json.data.data.value }}"
+  when: elk_vault_elastic_check.status == 200
+  no_log: true
+
+- name: Check if kibana_system password already in Vault
+  uri:
+    url: "https://127.0.0.1:8200/v1/secret/data/elk/kibana-system-password"
+    method: GET
+    headers:
+      X-Vault-Token: "{{ elk_vault_root_token }}"
+    ca_path: "{{ elk_tls_host_dir }}/ca.crt"
+    status_code: [200, 404]
+  register: elk_vault_kibana_system_check
+  no_log: true
+
+- name: Use kibana_system password from Vault
+  set_fact:
+    elk_kibana_system_password: "{{ elk_vault_kibana_system_check.json.data.data.value }}"
+  when: elk_vault_kibana_system_check.status == 200
+  no_log: true
+
 - name: Set vm.max_map_count for Elasticsearch
   ansible.posix.sysctl:
     name: vm.max_map_count
@@ -71,6 +120,38 @@
   retries: 10
   delay: 15
   until: elk_kibana_pw.status == 200
+  no_log: true
+
+## --- SECRETS → VAULT (premier run uniquement) ---
+
+- name: Store elastic password in Vault
+  uri:
+    url: "https://127.0.0.1:8200/v1/secret/data/elk/elastic-password"
+    method: POST
+    headers:
+      X-Vault-Token: "{{ elk_vault_root_token }}"
+    body_format: json
+    body:
+      data:
+        value: "{{ elk_elastic_password }}"
+    ca_path: "{{ elk_tls_host_dir }}/ca.crt"
+    status_code: 200
+  when: elk_vault_elastic_check.status == 404
+  no_log: true
+
+- name: Store kibana_system password in Vault
+  uri:
+    url: "https://127.0.0.1:8200/v1/secret/data/elk/kibana-system-password"
+    method: POST
+    headers:
+      X-Vault-Token: "{{ elk_vault_root_token }}"
+    body_format: json
+    body:
+      data:
+        value: "{{ elk_kibana_system_password }}"
+    ca_path: "{{ elk_tls_host_dir }}/ca.crt"
+    status_code: 200
+  when: elk_vault_kibana_system_check.status == 404
   no_log: true
 
 - name: Create Filebeat ILM policy

--- a/ansible/roles/filebeat/tasks/main.yml
+++ b/ansible/roles/filebeat/tasks/main.yml
@@ -17,6 +17,38 @@
     state: present
     update_cache: true
 
+## --- SECRET DEPUIS VAULT (mot de passe elastic, écrit par le rôle elk) ---
+
+- name: Slurp vault-init.json from ops-vm
+  slurp:
+    src: /root/vault-init.json
+  become: true
+  delegate_to: "{{ groups['ops'][0] }}"
+  register: filebeat_vault_init_raw
+  no_log: true
+
+- name: Set vault root token
+  set_fact:
+    filebeat_vault_root_token: "{{ (filebeat_vault_init_raw.content | b64decode | from_json).root_token }}"
+  no_log: true
+
+- name: Read elastic password from Vault
+  uri:
+    url: "https://127.0.0.1:8200/v1/secret/data/elk/elastic-password"
+    method: GET
+    headers:
+      X-Vault-Token: "{{ filebeat_vault_root_token }}"
+    ca_path: /etc/ssl/internal/ca.crt
+    status_code: 200
+  delegate_to: "{{ groups['ops'][0] }}"
+  register: filebeat_vault_elastic_resp
+  no_log: true
+
+- name: Set elastic password fact
+  set_fact:
+    filebeat_elastic_password: "{{ filebeat_vault_elastic_resp.json.data.data.value }}"
+  no_log: true
+
 - name: Deploy Filebeat config
   template:
     src: filebeat.yml.j2

--- a/ansible/roles/kibana/tasks/main.yml
+++ b/ansible/roles/kibana/tasks/main.yml
@@ -1,4 +1,53 @@
 ---
+## --- SECRETS DEPUIS VAULT (mot de passe elastic + kibana_system, écrits par le rôle elk) ---
+
+- name: Slurp vault-init.json from ops-vm
+  slurp:
+    src: /root/vault-init.json
+  become: true
+  delegate_to: "{{ groups['ops'][0] }}"
+  register: kibana_vault_init_raw
+  no_log: true
+
+- name: Set vault root token
+  set_fact:
+    kibana_vault_root_token: "{{ (kibana_vault_init_raw.content | b64decode | from_json).root_token }}"
+  no_log: true
+
+- name: Read elastic password from Vault
+  uri:
+    url: "https://127.0.0.1:8200/v1/secret/data/elk/elastic-password"
+    method: GET
+    headers:
+      X-Vault-Token: "{{ kibana_vault_root_token }}"
+    ca_path: /etc/ssl/internal/ca.crt
+    status_code: 200
+  delegate_to: "{{ groups['ops'][0] }}"
+  register: kibana_vault_elastic_resp
+  no_log: true
+
+- name: Set elastic password fact
+  set_fact:
+    kibana_elastic_password: "{{ kibana_vault_elastic_resp.json.data.data.value }}"
+  no_log: true
+
+- name: Read kibana_system password from Vault
+  uri:
+    url: "https://127.0.0.1:8200/v1/secret/data/elk/kibana-system-password"
+    method: GET
+    headers:
+      X-Vault-Token: "{{ kibana_vault_root_token }}"
+    ca_path: /etc/ssl/internal/ca.crt
+    status_code: 200
+  delegate_to: "{{ groups['ops'][0] }}"
+  register: kibana_vault_kibana_system_resp
+  no_log: true
+
+- name: Set kibana_system password fact
+  set_fact:
+    kibana_system_password: "{{ kibana_vault_kibana_system_resp.json.data.data.value }}"
+  no_log: true
+
 - name: Create Kibana directory
   file:
     path: "{{ kibana_dir }}/config"
@@ -42,20 +91,6 @@
   become: false
 
 ## --- FLEET TOKEN → VAULT ---
-
-# Lire le root token Vault depuis ops-vm
-- name: Slurp vault-init.json from ops-vm
-  slurp:
-    src: /root/vault-init.json
-  become: true
-  delegate_to: "{{ groups['ops'][0] }}"
-  register: kibana_vault_init_raw
-  no_log: true
-
-- name: Set vault root token for Fleet
-  set_fact:
-    kibana_vault_root_token: "{{ (kibana_vault_init_raw.content | b64decode | from_json).root_token }}"
-  no_log: true
 
 # 200 = token déjà en Vault, 404 = absent → créer
 - name: Check if Fleet enrollment token already in Vault


### PR DESCRIPTION
Previously, elk_elastic_password and elk_kibana_system_password were hardcoded as "changeme" in roles/elk/defaults/main.yml and used as-is on every run, by every role (elk, kibana, filebeat).

  Now:
  - "changeme" stays in the defaults file, but only as a bootstrap value for the very first run.
  - After Elasticsearch creates the kibana_system account, the elk role stores both passwords in Vault (secret/data/elk/elastic-password, secret/data/elk/kibana-system-password) — but only if they aren't already there.
  - On every later run, the elk role reads the passwords back from Vault instead of reusing the hardcoded default — so changeme is effectively only used once.
  - The kibana and filebeat roles no longer have their own hardcoded password — they read the same secrets from Vault (same pattern already used for the Fleet enrollment token).