### PR TITLE
Bastion hardening — firewall rules

### DIFF
--- a/ansible/inventory/onprem.py
+++ b/ansible/inventory/onprem.py
@@ -67,7 +67,8 @@ pfsense_cloud_wan = env.get("PFSENSE_CLOUD_WAN", "")
 pfsense_password  = env.get("PFSENSE_PASSWORD", "pfsense")
 vm_password       = env.get("VM_PASSWORD", "")
 pfsense_username  = env.get("PFSENSE_USERNAME", "admin")
-proxmox_host      = env.get("PROXMOX_HOST", "")
+proxmox_host        = env.get("PROXMOX_HOST", "")
+proxmox_host_remote = env.get("PROXMOX_HOST_REMOTE") or env.get("PROXMOX_NODE_ADDRESS_REMOTE", "")
 
 # Env proxmox ecole (pfSense comme jump host) — garder pour l'autre environnement
 # proxy_jump       = f"-o StrictHostKeyChecking=no -o ProxyJump={pfsense_username}@{pfsense_op_wan} -o ServerAliveInterval=30 -o ServerAliveCountMax=10"
@@ -77,11 +78,12 @@ proxmox_host      = env.get("PROXMOX_HOST", "")
 # Ancien: proxy_jump utilisait pfsense_op_wan comme jump → cassait quand PFSENSE_OP_WAN = IP interne
 proxmox_ssh_user  = env.get("PROXMOX_SSH_USER", "root")
 proxy_jump        = f"-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ProxyJump={proxmox_ssh_user}@{proxmox_host} -o ServerAliveInterval=30 -o ServerAliveCountMax=10"
-proxy_jump_cloud  = f"-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ProxyJump={proxmox_ssh_user}@{proxmox_host} -o ServerAliveInterval=30 -o ServerAliveCountMax=10"
+# Bastion/web sont sur PVE2 (cloud) — hôte Proxmox différent de l'onprem (PROXMOX_HOST)
+proxy_jump_cloud  = f"-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ProxyJump={proxmox_ssh_user}@{proxmox_host_remote} -o ServerAliveInterval=30 -o ServerAliveCountMax=10"
 
 # ProxyJump pour pfSense (Proxmox → IP WAN interne pfSense)
 proxy_jump_pfsense_op    = f"-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ProxyJump={proxmox_ssh_user}@{proxmox_host}"
-proxy_jump_pfsense_cloud = f"-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ProxyJump={proxmox_ssh_user}@{proxmox_host}"
+proxy_jump_pfsense_cloud = f"-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ProxyJump={proxmox_ssh_user}@{proxmox_host_remote}"
 
 pfsense_common = {
     "ansible_user":               "admin",

--- a/ansible/playbooks/teleport.yml
+++ b/ansible/playbooks/teleport.yml
@@ -6,3 +6,4 @@
     - base
     - tls
     - teleport
+    - fail2ban

--- a/ansible/roles/base/tasks/main.yml
+++ b/ansible/roles/base/tasks/main.yml
@@ -137,6 +137,11 @@
     state: enabled
     policy: deny
 
+# Les connexions rejetées remontent dans /var/log/ufw.log (rsyslog) → filebeat → Kibana
+- name: Enable UFW logging
+  community.general.ufw:
+    logging: "on"
+
 - name: Allow Vault port
   community.general.ufw:
     rule: allow

--- a/ansible/roles/fail2ban/defaults/main.yml
+++ b/ansible/roles/fail2ban/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+fail2ban_bantime: 1h
+fail2ban_findtime: 10m
+fail2ban_maxretry: 5
+fail2ban_ignoreip: "127.0.0.1/8 ::1"

--- a/ansible/roles/fail2ban/handlers/main.yml
+++ b/ansible/roles/fail2ban/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart fail2ban
+  systemd:
+    name: fail2ban
+    state: restarted
+  become: true

--- a/ansible/roles/fail2ban/tasks/main.yml
+++ b/ansible/roles/fail2ban/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: Install fail2ban
+  apt:
+    name: fail2ban
+    state: present
+    update_cache: true
+
+- name: Deploy fail2ban jail config
+  template:
+    src: jail.local.j2
+    dest: /etc/fail2ban/jail.local
+    mode: "0644"
+  notify: Restart fail2ban
+
+- name: Enable and start fail2ban
+  systemd:
+    name: fail2ban
+    enabled: true
+    state: started

--- a/ansible/roles/fail2ban/templates/jail.local.j2
+++ b/ansible/roles/fail2ban/templates/jail.local.j2
@@ -1,0 +1,11 @@
+[DEFAULT]
+bantime  = {{ fail2ban_bantime }}
+findtime = {{ fail2ban_findtime }}
+maxretry = {{ fail2ban_maxretry }}
+ignoreip = {{ fail2ban_ignoreip }}
+banaction = ufw
+
+[sshd]
+enabled  = true
+port     = ssh
+backend  = systemd

--- a/ansible/roles/filebeat/templates/filebeat.yml.j2
+++ b/ansible/roles/filebeat/templates/filebeat.yml.j2
@@ -5,6 +5,7 @@ filebeat.inputs:
     paths:
       - /var/log/syslog
       - /var/log/auth.log
+      - /var/log/ufw.log
 
   - type: filestream
     id: docker-containers

--- a/ansible/roles/teleport/tasks/main.yml
+++ b/ansible/roles/teleport/tasks/main.yml
@@ -146,9 +146,12 @@
 # FIREWALL — règles UFW spécifiques Teleport (443 déjà ouvert par le rôle base)
 # =============================================================================
 
-- name: Allow Teleport SSH proxy port (3022)
+# "limit" (et non "allow") : throttle au niveau connexion (iptables recent),
+# indépendant du protocole — protège 3022 sans avoir besoin de parser les
+# logs d'audit Teleport (que fail2ban ne sait pas lire).
+- name: Allow Teleport SSH proxy port (3022) with connection rate limiting
   community.general.ufw:
-    rule: allow
+    rule: limit
     port: "{{ teleport_proxy_ssh_port | string }}"
     proto: tcp
   become: true
@@ -165,6 +168,34 @@
   community.general.ufw:
     rule: allow
     port: "{{ teleport_auth_port | string }}"
+    proto: tcp
+    src: "{{ teleport_onprem_cidr }}"
+  become: true
+
+# Le rôle base ouvre le 22 sans restriction de source — on le retire ici pour
+# ne laisser SSH joignable que depuis les réseaux reliés par le VPN
+# site-to-site (DMZ Cloud + LAN on-prem). Tout le reste est rejeté par la
+# policy "default deny" déjà active (rôle base).
+- name: Remove unrestricted SSH rule added by base role
+  community.general.ufw:
+    rule: allow
+    port: "22"
+    proto: tcp
+    delete: true
+  become: true
+
+- name: Allow SSH from Cloud DMZ ({{ teleport_dmz_cidr }})
+  community.general.ufw:
+    rule: allow
+    port: "22"
+    proto: tcp
+    src: "{{ teleport_dmz_cidr }}"
+  become: true
+
+- name: Allow SSH from on-prem LAN via VPN ({{ teleport_onprem_cidr }})
+  community.general.ufw:
+    rule: allow
+    port: "22"
     proto: tcp
     src: "{{ teleport_onprem_cidr }}"
   become: true

--- a/docs/architecture/bastion.md
+++ b/docs/architecture/bastion.md
@@ -203,3 +203,179 @@ Accepte le certificat auto-signé et connecte-toi avec le compte `admin`.
 | 3080 | Proxy | Web UI + API |
 | 3022 | SSH node | Connexions SSH via Teleport |
 | 3025 | Auth | Communication interne Teleport |
+
+---
+
+## Durcissement — fail2ban (port 22)
+
+Le bastion est le seul host exposé sur internet (Teleport :443 et :3022 via DNAT). Le rôle `base` ouvre aussi le port 22 (SSH brut, utilisé par Ansible pour l'administration) sans protection anti-bruteforce. Le rôle `fail2ban` comble ce trou.
+
+### Structure des fichiers
+
+```
+ansible/
+├── roles/
+│   └── fail2ban/
+│       ├── defaults/main.yml
+│       ├── handlers/main.yml
+│       ├── tasks/main.yml
+│       └── templates/jail.local.j2
+└── playbooks/
+    └── teleport.yml   # roles: base, tls, teleport, fail2ban
+```
+
+### Fonctionnement
+
+`tasks/main.yml` :
+1. `apt install fail2ban`
+2. déploie `templates/jail.local.j2` → `/etc/fail2ban/jail.local` (notify: `Restart fail2ban`)
+3. active + démarre le service `fail2ban`
+
+`templates/jail.local.j2` :
+```ini
+[DEFAULT]
+bantime  = {{ fail2ban_bantime }}    # 1h par défaut
+findtime = {{ fail2ban_findtime }}   # 10m par défaut
+maxretry = {{ fail2ban_maxretry }}   # 5 tentatives
+ignoreip = {{ fail2ban_ignoreip }}   # 127.0.0.1/8 ::1
+banaction = ufw
+
+[sshd]
+enabled  = true
+port     = ssh
+backend  = systemd
+```
+
+Variables surchargeables dans `roles/fail2ban/defaults/main.yml` (`fail2ban_bantime`, `fail2ban_findtime`, `fail2ban_maxretry`, `fail2ban_ignoreip`).
+
+### Pourquoi `banaction = ufw` plutôt que l'action par défaut (iptables)
+
+Le firewall du repo est piloté entièrement via `community.general.ufw` (rôles `base`, `teleport`). L'action par défaut de fail2ban manipule directement des chaînes iptables custom (`f2b-sshd`), ce qui peut entrer en conflit d'ordonnancement avec les chaînes gérées par UFW. `banaction = ufw` fait passer fail2ban par `ufw insert ... deny from <ip>`, dans le même système que le reste du repo.
+
+### Pourquoi seulement le jail `sshd` (port 22) dans cette passe
+
+Le port 22 est exposé en interne (LAN/DMZ, utilisé par Ansible) — c'est la cible naturelle du jail `sshd` standard de fail2ban, qui parse les échecs d'authentification OpenSSH.
+
+Le port 3022 (proxy SSH Teleport, exposé sur internet via DNAT) n'est **pas couvert** : Teleport a son propre protocole et son propre format de log d'audit, pas des lignes `auth.log`/journald façon OpenSSH. Un jail fail2ban dédié demanderait un filtre custom sur les events d'audit Teleport. La voie plus naturelle pour throttle ce port est la fonctionnalité native `connection_limits` de Teleport (`teleport.yaml`) — pas encore configurée, à traiter séparément.
+
+### Vérification
+
+```bash
+ansible bastion -i inventory/onprem.py -m shell -a "fail2ban-client status sshd" --become
+```
+
+doit lister le jail `sshd` comme actif. Après un ban réel :
+
+```bash
+ansible bastion -i inventory/onprem.py -m shell -a "ufw status numbered" --become
+```
+
+doit montrer une règle `deny` insérée par fail2ban pour l'IP bannie.
+
+---
+
+## Durcissement — SSH (22) restreint au VPN site-to-site
+
+En plus de fail2ban, le port 22 n'est plus ouvert au monde : le rôle `teleport` retire la règle `allow 22` posée par `base` (sans restriction de source) et la remplace par deux règles scoping, dans `tasks/main.yml` (section FIREWALL) :
+
+```yaml
+- name: Remove unrestricted SSH rule added by base role
+  community.general.ufw:
+    rule: allow
+    port: "22"
+    proto: tcp
+    delete: true
+
+- name: Allow SSH from Cloud DMZ ({{ teleport_dmz_cidr }})
+  community.general.ufw:
+    rule: allow
+    port: "22"
+    proto: tcp
+    src: "{{ teleport_dmz_cidr }}"
+
+- name: Allow SSH from on-prem LAN via VPN ({{ teleport_onprem_cidr }})
+  community.general.ufw:
+    rule: allow
+    port: "22"
+    proto: tcp
+    src: "{{ teleport_onprem_cidr }}"
+```
+
+`teleport_dmz_cidr` (`10.255.255.248/29`) et `teleport_onprem_cidr` (`172.16.0.0/24`) sont les deux mêmes variables déjà utilisées pour restreindre le port auth 3025 — ce sont exactement les deux LAN reliés par le tunnel OpenVPN site-to-site (pfSense OP ↔ pfSense Cloud). Avec la policy `default deny` du rôle `base`, toute connexion SSH qui n'arrive pas via ce tunnel (donc depuis l'IP source du LAN on-prem ou de la DMZ cloud) est rejetée — y compris depuis l'IP publique du Proxmox cloud elle-même.
+
+**Risque à connaître avant de jouer le playbook** : si tu es connecté en SSH directement depuis une IP hors DMZ/on-prem (pas via le VPN), cette règle te coupe l'accès SSH brut. Garder une session Teleport active (port 3022, non affecté) comme filet de sécurité avant d'appliquer.
+
+### Vérification
+
+```bash
+ansible bastion -i inventory/onprem.py -m shell -a "ufw status numbered" --become
+```
+
+ne doit plus montrer de règle `22/tcp ALLOW Anywhere` — seulement les deux règles scoping sur `10.255.255.248/29` et `172.16.0.0/24`.
+
+---
+
+## Durcissement — rate limiting sur le port 3022 (Teleport SSH proxy)
+
+fail2ban (voir plus haut) ne protège que le port 22 : il a besoin de parser des lignes de log façon OpenSSH, et Teleport a son propre format d'audit que le filtre `sshd` ne comprend pas. Pour le port 3022 (proxy SSH Teleport, exposé sur internet via DNAT), on utilise `ufw limit` plutôt que `ufw allow` — dans `roles/teleport/tasks/main.yml` :
+
+```yaml
+- name: Allow Teleport SSH proxy port (3022) with connection rate limiting
+  community.general.ufw:
+    rule: limit
+    port: "{{ teleport_proxy_ssh_port | string }}"
+    proto: tcp
+```
+
+### Comment ça marche
+
+`ufw limit` s'appuie sur le module iptables `recent` : il compte les nouvelles connexions par IP source, et si une IP en fait **6 ou plus en 30 secondes**, les suivantes sont rejetées jusqu'à ce que le débit retombe. Contrairement à fail2ban, ça ne lit aucun log applicatif — juste le débit de connexions au niveau réseau, donc ça fonctionne indépendamment du protocole (Teleport, SSH brut, ou autre).
+
+**Exemple** : un scan automatisé tente 20 connexions en 10s sur 3022 → les 5 premières passent, la 6e et les suivantes sont bloquées tant que le rythme ne retombe pas sous le seuil sur une fenêtre glissante de 30s.
+
+**Compromis** : `limit` ne distingue pas trafic légitime et malveillant — un script qui ouvre plusieurs sessions `tsh ssh` en rafale peut se faire bloquer temporairement aussi. C'est pour ça que `443` (web UI, plusieurs connexions HTTP/2 simultanées par navigateur) reste en `allow` simple, et que seul 3022 passe en `limit`.
+
+### Vérification
+
+```bash
+ansible bastion -i inventory/onprem.py -m shell -a "ufw status verbose" --become
+```
+
+doit montrer `3022/tcp LIMIT Anywhere` (au lieu de `ALLOW`).
+
+---
+
+## Durcissement — logs UFW vers Kibana
+
+Les connexions rejetées par UFW (policy `default deny`) ne sont pas loguées par défaut. Le rôle `base` active le logging UFW, et le rôle `filebeat` expédie ces logs vers Elasticsearch comme le reste des logs système.
+
+**`roles/base/tasks/main.yml`** (juste après l'activation d'UFW) :
+```yaml
+- name: Enable UFW logging
+  community.general.ufw:
+    logging: "on"
+```
+
+**`roles/filebeat/templates/filebeat.yml.j2`** — `/var/log/ufw.log` ajouté à l'input `syslog` existant :
+```yaml
+  - type: filestream
+    id: syslog
+    paths:
+      - /var/log/syslog
+      - /var/log/auth.log
+      - /var/log/ufw.log
+```
+
+### Pourquoi ça suffit sans configurer rsyslog
+
+`ufw.log` est déjà écrit par défaut sur Ubuntu : le paquet `ufw` installe son propre drop-in rsyslog (`/etc/rsyslog.d/20-ufw.conf`) qui route les lignes `[UFW ...]` vers ce fichier (et les arrête là, pas de doublon dans `syslog`). Comme `rsyslog` tourne déjà (`/var/log/syslog`/`auth.log` sont déjà suivis par filebeat aujourd'hui), il n'y a rien d'autre à installer — juste activer le logging UFW et ajouter le chemin du fichier à filebeat.
+
+Appliqué sur tous les hosts (`base`/`filebeat` sont partagés), pas seulement le bastion : utile pour repérer du scan/bruteforce sur n'importe quelle VM, pas juste celle exposée à internet.
+
+### Vérification
+
+```bash
+ansible ops:bastion:web -i inventory/onprem.py -m shell -a "tail -5 /var/log/ufw.log" --become
+```
+
+puis, dans Kibana, chercher `log.file.path: "/var/log/ufw.log"`.

--- a/docs/architecture/ssh-auth.md
+++ b/docs/architecture/ssh-auth.md
@@ -132,6 +132,22 @@ ssh {
 }
 ```
 
+### 6. Cloud (PVE2) — attendre la fin de cloud-init avant de tenter SSH
+
+`scripts/deploy-remote.sh` suit la même séquence que `deploy.sh` pour bastion/website (`wait_for_agent` → `inject_ssh_key` → `configure_network` → `wait_for_ssh`), via le même mécanisme QEMU agent décrit au point 3.
+
+**Problème rencontré :** `wait_for_ssh` avait un timeout fixe de 120s, mais cloud-init sur bastion/website installe beaucoup de paquets (apt upgrade, kernel, bind9...) — observé en pratique à 200s+ pour bastion. Le script déclarait l'host "inaccessible" alors que la VM finissait simplement de démarrer, sans lien avec un vrai problème réseau/clé.
+
+**Fix — `wait_for_cloud_init()` :** entre `configure_network` et `wait_for_ssh`, le script lance `cloud-init status --wait` via l'agent QEMU (`POST .../agent/exec`) et poll `agent/exec-status` jusqu'à ce que la commande se termine (jusqu'à 10 min), avant de tenter le moindre SSH :
+
+```bash
+configure_network "${VM_ID_BASTION}" "bastion" ...
+wait_for_cloud_init "${VM_ID_BASTION}" "bastion"   # bloque sur "cloud-init status --wait"
+wait_for_ssh        "${BASTION_IP}"    "bastion"   # ne démarre qu'une fois cloud-init fini
+```
+
+Si l'agent ne répond pas (cas limite), la fonction continue sans bloquer plutôt que d'échouer tout le script — `wait_for_ssh` reste le filet de sécurité final (timeout relevé à 180s en complément).
+
 ---
 
 ## Séquence complète d'un déploiement

--- a/docs/decisions/DECISIONS.md
+++ b/docs/decisions/DECISIONS.md
@@ -168,6 +168,30 @@ puis recherche `log.file.path: "/var/log/ufw.log"` dans Kibana.
 
 ---
 
+## Attente cloud-init avant SSH dans deploy-remote.sh
+
+**Date :** 2026-06-23
+
+### Contexte
+
+`wait_for_ssh()` dans `scripts/deploy-remote.sh` timeoutait à 120s sur bastion/website alors que les VMs n'avaient pas fini cloud-init (observé à 200s+ pour bastion — apt upgrade, kernel, bind9...). Le script échouait sur un faux problème ("inaccessible") alors qu'il fallait juste attendre.
+
+### Décisions
+
+**`wait_for_cloud_init()` via l'agent QEMU plutôt qu'augmenter bêtement le timeout SSH**
+
+Augmenter le timeout de `wait_for_ssh` aurait masqué le problème sans le résoudre proprement (on devine une durée au lieu de vérifier l'état réel). À la place, une nouvelle fonction lance `cloud-init status --wait` via `agent/exec` (même mécanisme que `inject_ssh_key`/`configure_network`) et poll `agent/exec-status` jusqu'à la fin réelle de cloud-init (jusqu'à 10 min), insérée entre `configure_network` et `wait_for_ssh`. `wait_for_ssh` reste ensuite un filet de sécurité (timeout porté à 180s, largement suffisant une fois cloud-init confirmé terminé).
+
+**Échec silencieux plutôt que bloquant si l'agent ne répond pas**
+
+Si `agent/exec` ne renvoie pas de PID (cas limite, agent indisponible), la fonction continue sans bloquer le script — `wait_for_ssh` reste le dernier filet, pour ne pas introduire un nouveau point de blocage plus fragile que l'ancien.
+
+### Vérification
+
+Relancer `scripts/deploy-remote.sh` et observer dans les logs `"==> Attente fin cloud-init ..."` se terminer par `"cloud-init ... terminé."` avant que `wait_for_ssh` démarre.
+
+---
+
 ## Déploiement VMs Cloud PVE2 — bridges et réseau
 
 **Date :** 2026-06-01

--- a/docs/decisions/DECISIONS.md
+++ b/docs/decisions/DECISIONS.md
@@ -52,6 +52,122 @@ Pour les VMs PVE1 (ops-vm, services-vm), le trafic vers `10.255.255.249:3025` tr
 
 ---
 
+## fail2ban sur le bastion — durcissement port 22
+
+**Date :** 2026-06-23
+
+### Contexte
+
+Le bastion est le seul host exposé sur internet. Le rôle `base` ouvre le port 22 sur tous les hosts (y compris bastion) sans protection anti-bruteforce — c'est le premier trou évident à combler avant d'aller plus loin sur le durcissement.
+
+### Décisions
+
+**Nouveau rôle dédié (`fail2ban`) plutôt qu'ajout direct dans `base` ou `teleport`**
+
+`base` est partagé par tous les hosts (ops, services, bastion, web) — fail2ban n'est utile que sur un host exposé à internet, pas sur les VMs internes. L'ajouter dans `teleport.yml` (`roles: base, tls, teleport, fail2ban`) garde le scope correct sans polluer `base`.
+
+**`banaction = ufw` plutôt que l'action iptables par défaut de fail2ban**
+
+Tout le firewall du repo passe par `community.general.ufw` (`base`, `teleport`). L'action par défaut de fail2ban crée ses propres chaînes iptables (`f2b-sshd`), ce qui peut entrer en conflit d'ordonnancement avec les chaînes gérées par UFW. Configurer `banaction = ufw` fait passer les bans par `ufw insert ... deny`, dans le même système que le reste de l'infra.
+
+**Scope limité au jail `sshd` (port 22) — port 3022 (Teleport SSH proxy) volontairement exclu**
+
+Le jail `sshd` standard parse les logs d'échec d'auth OpenSSH (`backend = systemd`, journald sur Ubuntu 22.04) — il protège le port 22 utilisé par Ansible. Le port 3022 est le proxy SSH de Teleport : protocole et logs d'audit propres à Teleport, pas de lignes `auth.log` exploitables par le filtre `sshd`. Protéger ce port demanderait soit un filtre fail2ban custom sur les events d'audit Teleport, soit (plus naturel) la fonctionnalité native `connection_limits` de Teleport — non traité dans cette passe.
+
+### Vérification
+
+```bash
+ansible bastion -i inventory/onprem.py -m shell -a "fail2ban-client status sshd" --become
+```
+
+---
+
+## SSH (22) restreint au VPN site-to-site sur le bastion
+
+**Date :** 2026-06-23
+
+### Contexte
+
+fail2ban protège contre le bruteforce mais n'empêche pas une connexion SSH directe depuis n'importe quelle IP — le port 22 reste ouvert au monde via la règle générique du rôle `base`. Le bastion ne doit accepter SSH que depuis les réseaux reliés par le tunnel OpenVPN site-to-site (pfSense OP ↔ pfSense Cloud), pas depuis internet en direct.
+
+### Décisions
+
+**Suppression de la règle UFW générique de `base`, remplacée par deux règles scoping dans `teleport`**
+
+`base` ouvre `22/tcp` sans `src` sur tous les hosts — correct pour les VMs internes (ops, services, web), pas pour le bastion qui est le seul host avec une façade internet. Le rôle `teleport` (qui gère déjà le scoping CIDR du port 3025) supprime cette règle (`delete: true`) et la remplace par deux `allow` scopés sur `teleport_dmz_cidr` (`10.255.255.248/29`) et `teleport_onprem_cidr` (`172.16.0.0/24`) — réutilisation des mêmes variables que pour le port 3025, plutôt que d'introduire un nouveau CIDR dédié.
+
+**Pourquoi ces deux CIDR représentent "le VPN"**
+
+Le tunnel OpenVPN site-to-site (`vpn_tunnel_network`, rôle `pfsense-cloud`) relie justement le LAN on-prem (`172.16.0.0/24`) et la DMZ cloud (`10.255.255.248/29`). Restreindre SSH à ces deux plages revient à n'accepter que le trafic qui transite par ce tunnel — combiné à la policy `default deny` du rôle `base`, toute autre source (y compris l'IP publique du Proxmox cloud) est rejetée.
+
+**Risque de lockout — pas traité automatiquement**
+
+Si l'opérateur est connecté en SSH brut depuis une IP hors de ces deux plages au moment du run, il perd l'accès SSH (mais pas Teleport, port 3022, non touché). Documenté dans `docs/architecture/bastion.md` comme précaution avant de jouer `teleport.yml`.
+
+### Vérification
+
+```bash
+ansible bastion -i inventory/onprem.py -m shell -a "ufw status numbered" --become
+```
+
+---
+
+## Rate limiting UFW sur le port 3022 (Teleport SSH proxy)
+
+**Date :** 2026-06-23
+
+### Contexte
+
+fail2ban ne couvre que le port 22 (jail `sshd` standard, basé sur le format de log OpenSSH). Le port 3022, proxy SSH de Teleport, utilise son propre protocole et son propre format d'audit — pas de bruteforce-protection dessus malgré le fait qu'il soit exposé sur internet via DNAT.
+
+### Décisions
+
+**`ufw limit` plutôt qu'un filtre fail2ban custom**
+
+Écrire un filtre fail2ban pour le format d'audit Teleport (JSON structuré, pas des lignes `auth.log`) est possible mais plus lourd à maintenir. `ufw limit` repose sur le module iptables `recent` : il bloque une IP source qui ouvre 6 connexions ou plus en 30 secondes, indépendamment du protocole — donc applicable à Teleport sans rien savoir de son format de log. Seul changement : `rule: allow` → `rule: limit` dans `roles/teleport/tasks/main.yml`.
+
+**Pas appliqué au port 443 (web UI)**
+
+`limit` ne distingue pas trafic légitime de malveillant — un navigateur ouvrant plusieurs connexions HTTP/2 en rafale pourrait se faire bloquer. Le risque de faux positif est plus élevé sur 443 (usage humain interactif) que sur 3022 (sessions SSH, moins fréquentes). Le port 443 reste en `allow` simple.
+
+### Vérification
+
+```bash
+ansible bastion -i inventory/onprem.py -m shell -a "ufw status verbose" --become
+```
+
+doit montrer `3022/tcp LIMIT Anywhere`.
+
+---
+
+## Logs UFW expédiés vers Kibana via filebeat
+
+**Date :** 2026-06-23
+
+### Contexte
+
+UFW (policy `default deny`, rôles `base`/`teleport`) rejette déjà du trafic indésirable, mais ces rejets ne sont loggés nulle part par défaut — aucune visibilité sur les tentatives bloquées (scan, bruteforce, erreurs de config).
+
+### Décisions
+
+**`ufw logging on` dans `base` (tous les hosts, pas seulement bastion)**
+
+Le coût est négligeable (logs uniquement sur connexions effectivement filtrées) et utile partout, pas seulement sur l'host exposé à internet — ça peut aussi révéler du trafic interne anormal sur ops/services/web.
+
+**Réutilisation de l'input `syslog` existant de filebeat plutôt qu'un nouvel input dédié**
+
+`/var/log/ufw.log` est ajouté aux `paths` de l'input `filestream` `syslog` déjà présent dans `roles/filebeat/templates/filebeat.yml.j2` (qui suit déjà `/var/log/syslog` et `/var/log/auth.log`). Pas de nouveau rôle ni de module Elastic dédié — `ufw.log` existe déjà nativement via le drop-in rsyslog livré avec le paquet `ufw` (`/etc/rsyslog.d/20-ufw.conf`), donc rien à configurer côté rsyslog.
+
+### Vérification
+
+```bash
+ansible ops:bastion:web -i inventory/onprem.py -m shell -a "tail -5 /var/log/ufw.log" --become
+```
+
+puis recherche `log.file.path: "/var/log/ufw.log"` dans Kibana.
+
+---
+
 ## Déploiement VMs Cloud PVE2 — bridges et réseau
 
 **Date :** 2026-06-01

--- a/scripts/deploy-remote.sh
+++ b/scripts/deploy-remote.sh
@@ -110,10 +110,54 @@ ENDJSON
   echo "    Réseau configuré sur ${label}."
 }
 
+# Attend la fin réelle de cloud-init via l'agent QEMU (cloud-init status --wait),
+# plutôt que de tenter SSH avec un timeout fixe pendant que la VM installe
+# encore ses paquets (apt, kernel...) — évite les faux "inaccessible".
+wait_for_cloud_init() {
+  local vmid="$1"
+  local label="$2"
+  local timeout=600
+  local elapsed=0
+  echo ""
+  echo "==> Attente fin cloud-init ${label} (VM ${vmid})..."
+  local tmpjson
+  tmpjson=$(mktemp)
+  cat > "$tmpjson" << 'ENDJSON'
+{"command":["cloud-init","status","--wait"]}
+ENDJSON
+  local pid
+  pid=$(curl -s -k -X POST \
+    "${PROXMOX_API_REMOTE}/nodes/${PROXMOX_NODE_REMOTE}/qemu/${vmid}/agent/exec" \
+    -H "CSRFPreventionToken: ${CSRF}" \
+    -b "PVEAuthCookie=${TICKET}" \
+    -H "Content-Type: application/json" \
+    -d "@${tmpjson}" | python3 -c "import sys,json; print(json.load(sys.stdin)['data']['pid'])" 2>/dev/null)
+  rm -f "$tmpjson"
+  if [[ -z "$pid" ]]; then
+    echo "    Impossible de lancer cloud-init status sur ${label}, on continue sans attendre."
+    return
+  fi
+  while true; do
+    local exited
+    exited=$(curl -s -k -b "PVEAuthCookie=${TICKET}" \
+      "${PROXMOX_API_REMOTE}/nodes/${PROXMOX_NODE_REMOTE}/qemu/${vmid}/agent/exec-status?pid=${pid}" | \
+      python3 -c "import sys,json; print('1' if json.load(sys.stdin).get('data',{}).get('exited') else '0')" 2>/dev/null || echo "0")
+    [[ "$exited" == "1" ]] && break
+    sleep 10
+    elapsed=$((elapsed + 10))
+    echo "    ${elapsed}s — cloud-init ${label} toujours en cours..."
+    if [[ $elapsed -ge $timeout ]]; then
+      echo "    cloud-init ${label} pas confirmé terminé après ${timeout}s — on tente SSH quand même."
+      return
+    fi
+  done
+  echo "    cloud-init ${label} terminé."
+}
+
 wait_for_ssh() {
   local host="$1"
   local label="$2"
-  local timeout=120
+  local timeout=180
   local elapsed=0
   echo ""
   echo "==> Vérification SSH ${label} (${host})..."
@@ -378,6 +422,9 @@ inject_ssh_key "${VM_ID_WEBSITE}"  "website"
 
 configure_network "${VM_ID_BASTION}" "bastion" "${BASTION_IP}/29" "10.255.255.254"
 configure_network "${VM_ID_WEBSITE}"  "website" "${WEBSITE_IP}/28" "192.168.255.254"
+
+wait_for_cloud_init "${VM_ID_BASTION}" "bastion"
+wait_for_cloud_init "${VM_ID_WEBSITE}"  "website"
 
 wait_for_ssh "${BASTION_IP}" "bastion"
 wait_for_ssh "${WEBSITE_IP}"  "website"


### PR DESCRIPTION
The bastion is the only host with internet-facing services (Teleport on 443/3022), so it got four new layers of protection:

  1. SSH (22) scoped to trusted networks only — the open allow 22 from anywhere rule (inherited from the shared base role) is removed on bastion and replaced with two scoped rules: allow only from the Cloud DMZ (10.255.255.248/29) and the on-prem LAN (172.16.0.0/24) — the two networks joined by the
  site-to-site VPN. Everything else is rejected by the existing default deny policy.
  2. fail2ban on port 22 — standard sshd jail (5 failed attempts / 10 min → 1h ban), using banaction = ufw so bans go through the same UFW system as the rest of the repo instead of fail2ban's own iptables chains.
  3. Rate limiting on port 3022 (Teleport SSH proxy) — switched from ufw allow to ufw limit (max 6 new connections / 30s per source IP). fail2ban can't cover this port since Teleport has its own auth/audit format, not OpenSSH-style logs — ufw limit works at the connection-rate level instead, so it protects
  Teleport without needing to parse its logs.
  4. UFW logging → Kibana — ufw logging on (applied repo-wide via base, not just bastion), and filebeat now tails /var/log/ufw.log alongside syslog/auth.log, so rejected/limited connection attempts are searchable in Kibana.

  Port 443 (Teleport web UI) intentionally stays on plain allow — limit would risk blocking legitimate browser traffic (multiple HTTP/2 connections at once).