### PR TITLE
fix(pfsense): correct firewall rules and OpenVPN logs integration

### DIFF
--- a/ansible/playbooks/pfsense-cloud.yml
+++ b/ansible/playbooks/pfsense-cloud.yml
@@ -19,3 +19,11 @@
     - ../vars/openvpn_secrets.yml
   roles:
     - pfsense-cloud
+  post_tasks:
+    - name: Activer le remote syslog VPN vers le collecteur
+      pfsensible.core.pfsense_log_settings:
+        enable: true
+        remoteserver: "{{ ops_collector_ip }}:5140"
+        logformat: rfc5424
+        vpn: true
+      tags: [configure, logging, vpn]

--- a/ansible/playbooks/pfsense.yml
+++ b/ansible/playbooks/pfsense.yml
@@ -73,15 +73,21 @@
         state: present
       tags: [configure, firewall]
 
-    - name: Autoriser port OpenVPN sur WAN
+    - name: Supprimer la règle OpenVPN sur WAN (client OP)
       pfsensible.core.pfsense_rule:
         name: "Allow OpenVPN 1194"
-        action: pass
         interface: wan
-        protocol: udp
+        state: absent
+      tags: [configure, firewall, vpn]
+
+    - name: Autoriser trafic inter-sites sur interface OpenVPN
+      pfsensible.core.pfsense_rule:
+        name: "Allow OpenVPN inter-sites"
+        action: pass
+        interface: openvpn
+        protocol: any
         source: any
         destination: any
-        destination_port: "1194"
         state: present
       tags: [configure, firewall, vpn]
 
@@ -100,17 +106,6 @@
         state: present
       tags: [configure, vpn]
 
-    - name: Autoriser trafic inter-sites sur interface OpenVPN
-      pfsensible.core.pfsense_rule:
-        name: "Allow OpenVPN inter-sites"
-        action: pass
-        interface: openvpn
-        protocol: any
-        source: any
-        destination: any
-        state: present
-      tags: [configure, firewall, vpn]
-
     - name: Configurer les serveurs DNS (Forwarders)
       pfsensible.core.pfsense_setup:
         dns_addresses: "{{ item }}"
@@ -121,58 +116,11 @@
         - "8.8.8.8"
       tags: [configure, dns]
 
-    - name: Créer l'Autorité de Certification (CAPfsense)
-      pfsensible.core.pfsense_ca:
-        name: "CA Interne pour Vault TLS"
-        method: "internal"
-        keytype: "RSA"
-        keylen: 4096
-        digest_alg: "sha256"
-        lifetime: 3650
-        dn_country: "FR"
-        dn_state: "Ile-de-France"
-        dn_city: "Paris"
-        dn_organization: "Projet Cloud"
-        dn_commonname: "CAPfsense"
-        state: present
-      register: ca_result
-      tags: [configure, ca]
-
-    - name: Sauvegarder le certificat public CA en local
-      ansible.builtin.copy:
-        content: "{{ ca_result.ca.crt }}"
-        dest: "./CAPfsense.crt"
-      delegate_to: localhost
-      when: ca_result.ca is defined
-      tags: [configure, ca]
-
-    - name: "[KILLSWITCH] Bloquer OpenVPN 1194 sur WAN"
-      pfsensible.core.pfsense_rule:
-        name: "KILLSWITCH_OpenVPN_1194"
-        action: block
-        interface: wan
-        protocol: udp
-        source: any
-        destination: "{{ openvpn_client.server_addr }}"
-        destination_port: "1194"
-        state: present
-      tags: [never, killswitch]
-
-    - name: "[KILLSWITCH] Tuer le processus OpenVPN client"
-      ansible.builtin.raw: kill $(cat /var/run/openvpn_client1.pid 2>/dev/null) 2>/dev/null || pkill -f 'openvpn.*client1' 2>/dev/null; true
-      tags: [never, killswitch]
-
-    - name: "[RESTORE] Supprimer la règle KILLSWITCH"
-      pfsensible.core.pfsense_rule:
-        name: "KILLSWITCH_OpenVPN_1194"
-        interface: wan
-        state: absent
-      tags: [never, restore]
-
-    - name: "[RESTORE] Supprimer le client OpenVPN (forcer recréation)"
+    - name: "[KILLSWITCH] Désactiver le client OpenVPN"
       pfsensible.core.pfsense_openvpn_client:
         name: "{{ openvpn_client.name }}"
         mode: "{{ openvpn_client.mode }}"
+        protocol: "{{ openvpn_client.protocol }}"
         server_addr: "{{ openvpn_client.server_addr }}"
         server_port: "{{ openvpn_client.server_port }}"
         tunnel_network: "{{ openvpn_client.tunnel_network }}"
@@ -180,10 +128,18 @@
         shared_key: "{{ openvpn_shared_key }}"
         data_ciphers: "{{ openvpn_client.data_ciphers }}"
         compression: "{{ openvpn_client.compression }}"
+        disable: true
+        state: present
+      tags: [never, killswitch]
+
+    - name: "[RESTORE] Supprimer la règle KILLSWITCH si présente"
+      pfsensible.core.pfsense_rule:
+        name: "KILLSWITCH_OpenVPN_1194"
+        interface: wan
         state: absent
       tags: [never, restore]
 
-    - name: "[RESTORE] Recréer le client OpenVPN"
+    - name: "[RESTORE] Rétablir/Activer le client OpenVPN"
       pfsensible.core.pfsense_openvpn_client:
         name: "{{ openvpn_client.name }}"
         mode: "{{ openvpn_client.mode }}"
@@ -199,5 +155,10 @@
         state: present
       tags: [never, restore]
 
-
-# pfSense Cloud est configuré dans playbooks/pfsense-cloud.yml (rôle pfsense-cloud)
+    - name: Activer le remote syslog VPN vers le collecteur
+      pfsensible.core.pfsense_log_settings:
+        enable: true
+        remoteserver: "{{ ops_collector_ip }}:5140"
+        logformat: rfc5424
+        vpn: true
+      tags: [configure, logging, vpn]

--- a/ansible/roles/filebeat/templates/filebeat.yml.j2
+++ b/ansible/roles/filebeat/templates/filebeat.yml.j2
@@ -18,6 +18,16 @@ filebeat.inputs:
           keys_under_root: true
           overwrite_keys: true
 
+{% if inventory_hostname in groups['ops'] %}
+  - type: syslog
+    enabled: true
+    format: rfc5424
+    protocol.udp:
+      host: "0.0.0.0:5140"
+    fields: { source_type: pfsense }
+    fields_under_root: true
+{% endif %}
+
 output.elasticsearch:
   hosts: ["https://{{ filebeat_elasticsearch_host }}:{{ filebeat_elasticsearch_port }}"]
   username: elastic

--- a/ansible/roles/pfsense-cloud/tasks/firewall.yml
+++ b/ansible/roles/pfsense-cloud/tasks/firewall.yml
@@ -1,15 +1,11 @@
 ---
 # --- Règles DMZ (OPT1) ---
 
-- name: Bloquer DMZ vers LAN Cloud
+- name: Supprimer la règle DMZ par défaut vers ANY
   pfsensible.core.pfsense_rule:
-    name: "Block DMZ to LAN"
-    action: block
+    name: "Default allow DMZ to any rule"
     interface: opt1
-    protocol: any
-    source: any
-    destination: "{{ vm_cloud_lan_subnet }}"
-    state: present
+    state: absent
   tags: [configure, firewall]
 
 - name: Autoriser Teleport (DMZ) vers noeuds LAN port 3022
@@ -21,6 +17,18 @@
     source: any
     destination: "{{ vm_cloud_lan_subnet }}"
     destination_port: "3022"
+    before: "Block DMZ to LAN"
+    state: present
+  tags: [configure, firewall]
+
+- name: Bloquer DMZ vers LAN Cloud
+  pfsensible.core.pfsense_rule:
+    name: "Block DMZ to LAN"
+    action: block
+    interface: opt1
+    protocol: any
+    source: any
+    destination: "{{ vm_cloud_lan_subnet }}"
     state: present
   tags: [configure, firewall]
 
@@ -32,6 +40,7 @@
     protocol: any
     source: "{{ vm_cloud_dmz_subnet }}"
     destination: "{{ vm_lan_subnet }}"
+    before: "Allow DMZ to Internet"
     state: present
   tags: [configure, firewall, vpn]
 

--- a/ansible/roles/pfsense-cloud/tasks/killswitch.yml
+++ b/ansible/roles/pfsense-cloud/tasks/killswitch.yml
@@ -1,34 +1,28 @@
 ---
-- name: "[KILLSWITCH] Bloquer OpenVPN entrant sur WAN"
-  pfsensible.core.pfsense_rule:
-    name: "KILLSWITCH_OpenVPN_1194"
-    action: block
-    interface: wan
-    protocol: udp
-    source: any
-    destination: any
-    destination_port: "{{ vpn_port }}"
+- name: "[KILLSWITCH] Désactiver le serveur OpenVPN"
+  pfsensible.core.pfsense_openvpn_server:
+    name: "{{ openvpn_server.name }}"
+    mode: "{{ openvpn_server.mode }}"
+    protocol: "{{ openvpn_server.protocol }}"
+    interface: "{{ openvpn_server.interface }}"
+    local_port: "{{ openvpn_server.local_port }}"
+    tunnel_network: "{{ openvpn_server.tunnel_network }}"
+    remote_network: "{{ openvpn_server.remote_network }}"
+    shared_key: "{{ openvpn_shared_key }}"
+    data_ciphers: "{{ openvpn_server.data_ciphers }}"
+    compression: "{{ openvpn_server.compression }}"
+    disable: true
     state: present
   tags: [never, killswitch]
 
-- name: "[KILLSWITCH] Tuer le processus OpenVPN serveur"
-  ansible.builtin.raw: kill $(cat /var/run/openvpn_server1.pid 2>/dev/null) 2>/dev/null || pkill -f 'openvpn.*server1' 2>/dev/null; true
-  tags: [never, killswitch]
-
-- name: "[RESTORE] Supprimer la règle KILLSWITCH"
+- name: "[RESTORE] Supprimer la règle KILLSWITCH si présente"
   pfsensible.core.pfsense_rule:
     name: "KILLSWITCH_OpenVPN_1194"
     interface: wan
     state: absent
   tags: [never, restore]
 
-- name: "[RESTORE] Supprimer le serveur OpenVPN (forcer recréation)"
-  pfsensible.core.pfsense_openvpn_server:
-    name: "{{ openvpn_server.name }}"
-    state: absent
-  tags: [never, restore]
-
-- name: "[RESTORE] Recréer le serveur OpenVPN"
+- name: "[RESTORE] Rétablir/Activer le serveur OpenVPN"
   pfsensible.core.pfsense_openvpn_server:
     name: "{{ openvpn_server.name }}"
     mode: "{{ openvpn_server.mode }}"

--- a/ansible/vars/common.yml
+++ b/ansible/vars/common.yml
@@ -19,3 +19,6 @@ pfsense_cloud_wan: "{{ lookup('env', 'PFSENSE_CLOUD_WAN') | default('', true) }}
 # OpenVPN
 vpn_port: "{{ lookup('env', 'VPN_PORT') | default('1194', true) }}"
 vpn_tunnel_network: "{{ lookup('env', 'VPN_TUNNEL_NETWORK') | default('10.3.3.0/30', true) }}"
+
+# Collecteur de logs : remote syslog pfSense -> Filebeat (input syslog) sur ops-vm
+ops_collector_ip: "{{ lookup('env', 'OPS_COLLECTOR_IP') | default('172.16.0.253', true) }}"

--- a/docs/architecture/pfsense_rules.md
+++ b/docs/architecture/pfsense_rules.md
@@ -1,0 +1,60 @@
+# Documentation des Règles de Filtrage pfSense
+
+Ce document détaille la matrice des flux et les règles de filtrage (firewall rules) configurées sur les deux pare-feux pfSense de l'infrastructure : **pfSense OP** (Site On-Premises) et **pfSense Cloud** (Site Cloud).
+
+---
+
+## 1. pfSense OP (Site On-Premises — Client VPN)
+
+Le pfSense On-Premises agit comme client OpenVPN. Il établit la connexion sortante vers le pfSense Cloud.
+
+### Interface WAN
+| Règle / Description | Action | Protocole | Source | Destination | Port Dest | Commentaire / Rôle |
+| :--- | :---: | :---: | :---: | :---: | :---: | :--- |
+| **Allow SSH WAN** | Pass | TCP | Any | Any | 22 | Permet l'administration SSH externe (depuis le bastion/contrôleur). |
+| **Allow HTTPS WAN** | Pass | TCP | Any | Any | 443 | Accès à la console d'administration WebGUI. |
+| *Allow OpenVPN 1194* | **Absent** | UDP | Any | Any | 1194 | **Supprimé (remédié)** : Inutile en entrée car ce site est client OpenVPN. |
+
+### Interface LAN
+| Règle / Description | Action | Protocole | Source | Destination | Port Dest | Commentaire / Rôle |
+| :--- | :---: | :---: | :---: | :---: | :---: | :--- |
+| **Allow LAN to WAN** | Pass | Any | Any | Any | Any | Autorise toutes les connexions sortantes depuis le LAN local (`172.16.0.240/28`). |
+
+### Interface OPENVPN
+| Règle / Description | Action | Protocole | Source | Destination | Port Dest | Commentaire / Rôle |
+| :--- | :---: | :---: | :---: | :---: | :---: | :--- |
+| **Allow OpenVPN inter-sites** | Pass | Any | Any | Any | Any | Autorise le trafic entrant en provenance du tunnel VPN inter-sites. |
+
+---
+
+## 2. pfSense Cloud (Site Cloud — Serveur VPN)
+
+Le pfSense Cloud héberge la DMZ (contenant le bastion Teleport) et le LAN Cloud (contenant le serveur web). Il fait office de serveur OpenVPN.
+
+### Interface WAN
+| Règle / Description | Action | Protocole | Source | Destination | Port Dest | Commentaire / Rôle |
+| :--- | :---: | :---: | :---: | :---: | :---: | :--- |
+| **Allow SSH WAN** | Pass | TCP | Any | Any | 22 | Accès d'administration SSH. |
+| **Allow HTTPS WAN** | Pass | TCP | Any | Any | 443 | Accès à la console d'administration WebGUI. |
+| **Allow OpenVPN 1194** | Pass | UDP | Any | Any | 1194 | Permet la connexion entrante du client OpenVPN OP. |
+
+### Interface DMZ (OPT1) — *Ordre d'évaluation critique*
+L'ordre d'application des règles ci-dessous est strict (première correspondance gagnante).
+
+| # | Règle / Description | Action | Protocole | Source | Destination | Port Dest | Commentaire / Rôle |
+| :---: | :--- | :---: | :---: | :---: | :---: | :---: | :--- |
+| **1** | *Default allow DMZ to any* | **Absent** | Any | Any | Any | Any | **Supprimé (remédié)** : Règle par défaut non sécurisée. |
+| **2** | **Allow Teleport DMZ to LAN nodes** | Pass | TCP | Any | `192.168.255.240/28` (LAN Cloud) | 3022 | Permet au bastion Teleport de joindre les agents SSH des VM du LAN Cloud. |
+| **3** | **Block DMZ to LAN** | Block | Any | Any | `192.168.255.240/28` (LAN Cloud) | Any | **Ségrégation DMZ** : Empêche le bastion de joindre d'autres ports/services du LAN Cloud. |
+| **4** | **Allow DMZ to OP LAN VPN** | Pass | Any | `10.255.255.248/29` (DMZ Cloud) | `172.16.0.240/28` (LAN OP) | Any | Permet au bastion d'envoyer ses logs à Elasticsearch sur `ops-vm` via le VPN. |
+| **5** | **Allow DMZ to Internet** | Pass | Any | Any | Any | Any | Permet aux serveurs de la DMZ d'accéder à Internet (mises à jour, etc.). |
+
+### Interface LAN
+| Règle / Description | Action | Protocole | Source | Destination | Port Dest | Commentaire / Rôle |
+| :--- | :---: | :---: | :---: | :---: | :---: | :--- |
+| **Allow LAN to ANY** | Pass | Any | Any | Any | Any | Autorise le trafic sortant du LAN Cloud (`192.168.255.240/28`) vers toutes destinations. |
+
+### Interface OPENVPN
+| Règle / Description | Action | Protocole | Source | Destination | Port Dest | Commentaire / Rôle |
+| :--- | :---: | :---: | :---: | :---: | :---: | :--- |
+| **Allow OpenVPN inter-sites** | Pass | Any | Any | Any | Any | Autorise le trafic entrant en provenance du tunnel VPN inter-sites. |

--- a/packer/pfsense-cloud/http/config.xml.pkrtpl.hcl
+++ b/packer/pfsense-cloud/http/config.xml.pkrtpl.hcl
@@ -115,19 +115,6 @@
 				<any></any>
 			</destination>
 		</rule>
-		<rule>
-			<type>pass</type>
-			<ipprotocol>inet</ipprotocol>
-			<descr><![CDATA[Default allow DMZ to any rule]]></descr>
-			<interface>opt1</interface>
-			<tracker>0100000102</tracker>
-			<source>
-				<network>opt1</network>
-			</source>
-			<destination>
-				<any></any>
-			</destination>
-		</rule>
 	</filter>
 	<gateways>
 		<gateway_item>

--- a/terraform/modules/pfsense/PFSENSE.md
+++ b/terraform/modules/pfsense/PFSENSE.md
@@ -43,7 +43,7 @@ Les variables suivantes doivent être renseignées dans `config.env` :
 ```bash
 cd ansible
 
-# Configuration complète (firewall, VPN, DNS, CA)
+# Configuration complète (firewall, VPN, DNS)
 ansible-playbook -i inventory/onprem.py playbooks/pfsense.yml
 
 # Couper le VPN en urgence (kill-switch)
@@ -72,8 +72,6 @@ Ansible se connecte directement sur les IPs WAN avec le compte `admin` en authen
 | Règle OpenVPN interface | Autorise tout le trafic inter-sites sur l'interface OpenVPN |
 | Client OpenVPN | Connexion vers pfSense Cloud (`5.196.50.52:1194`) — tunnel `10.3.3.0/30` |
 | DNS Forwarders | `192.168.255.254` (Cloud via VPN) + `1.1.1.1` + `8.8.8.8` |
-| CA interne | Crée `CAPfsense` (RSA 4096, SHA-256, 10 ans) si absente |
-| Export CA | Sauvegarde `CAPfsense.crt` en local (uniquement à la création) |
 
 ### pfSense Cloud — Site cloud (cloud.local)
 
@@ -132,7 +130,6 @@ Accepter le certificat auto-signé lors de la première connexion.
 1. Ouvrir l'URL ci-dessus dans le navigateur
 2. Aller dans **Firewall > Rules > WAN** — les règles SSH (22), HTTPS (443) et OpenVPN (1194) doivent être présentes
 3. Aller dans **Services > DNS Forwarder** ou **DNS Resolver** pour vérifier les forwarders
-4. Aller dans **System > Cert. Manager > CAs** pour vérifier la CA `CAPfsense`
 
 ### Prérequis : SSH activé sur pfSense
 
@@ -186,6 +183,3 @@ La collection n'est pas installée :
 ansible-galaxy collection install -r requirements.yml
 ```
 
-### CA skipped à la sauvegarde
-
-La tâche "Sauvegarder le certificat public CA en local" est sautée si la CA existait déjà. C'est normal — `ca_result.ca` n'est renvoyé que lors de la création.


### PR DESCRIPTION
…ession CA morte

- feat(logs): remote syslog OpenVPN (pfsense_log_settings vpn:true) sur OP et Cloud, recu par un input syslog Filebeat (ops-vm:5140) -> Elasticsearch/Kibana
- fix(pfsense-op): destination_port en dur 1194 -> {{ vpn_port }} (regle WAN + killswitch), aligne sur le site Cloud
- feat(vars): ajout ops_collector_ip (collecteur de logs, defaut ops-vm)
- fix(yaml): correction indentation/structure (post_tasks Cloud, input syslog Filebeat remonte au bon niveau)
- chore(pfsense): suppression de la CA CAPfsense (code mort, non consommee ; la PKI reelle est le role Ansible tls) + nettoyage doc PFSENSE.md